### PR TITLE
Generate base64-encoded slugs instead.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -42,7 +42,6 @@ import ChapterManager from "@/pages/ChapterManager";
 import GitHubUtils from "@/GitHubUtils";
 import Series from "@/model/Series";
 import ChapterEditor from "@/pages/ChapterEditor";
-import GitIO from "@/GitIO";
 
 export default {
   name: 'App',
@@ -58,7 +57,9 @@ export default {
       target.loadingStatus = 'Creating URL';
       target.loading = true;
       GitHubUtils.getCurrentBranch(this.repoName, this.fs).then(value => {
-        return GitIO.create(GitHubUtils.getSeriesUrl(fileName, value, this.repoName, this.fs))
+        return GitHubUtils.getBase64EncodedSlug(
+          GitHubUtils.getSeriesUrl(fileName, value, this.repoName, this.fs)
+        );
       }).then(value => {
         target.loading = false;
         let url = 'https://cubari.moe/proxy/gist/' + value + '/';

--- a/src/GitHubUtils.js
+++ b/src/GitHubUtils.js
@@ -148,6 +148,15 @@ export default class GitHubUtils {
         return 'https://raw.githubusercontent.com/' + repo + '/' + branch + '/' + name;
     }
 
+    static getBase64EncodedSlug(rawGithubUrl) {
+        const url = new URL(rawGithubUrl);
+        // Base64 URL-encoded with no padding
+        return btoa(url.host.split(".")[0] + url.pathname)
+            .replace(/\+/g, "-")
+            .replace(/\//g, "_")
+            .replace(/=/g, "");
+    }
+
     static getTopics(repo, username, pat) {
         return new RepositoryExtension(repo, {
             username: username,


### PR DESCRIPTION
In light of GitHub's [git.io deprecation](https://github.blog/changelog/2022-01-11-git-io-no-longer-accepts-new-urls/), we updated Cubari to use a new scheme for the gist URLs. The only change is that the gist/raw content paths are base64 URL encoded as the slugs now.

This PR adds the change to support this.

I also removed the git.io calls completely since they're no longer returning existing shortcodes from the creation request either, so we can't use that as a fallback. **This is a breaking change** since previous users will no longer see their old shortcodes unless they saved it elsewhere.

(Alg made a reddit post [here](https://old.reddit.com/r/manga/comments/s1x668/sl_cubarimoe_gist_links_are_now_deprecated/) ICYMI)