### PR TITLE
Add Catbox proxy

### DIFF
--- a/src/model/Proxy.js
+++ b/src/model/Proxy.js
@@ -9,6 +9,7 @@ export default class Proxy {
             return '/proxy/api/' + name + '/chapter/' + btoa(exec[0]) + '/';
         }),
         new Proxy('dynasty', 'Dynasty Scans', /^https:\/\/dynasty-scans.com\/chapters\/([\d\w_]+_ch[\d]+)$/),
+        new Proxy('catbox', 'Catbox', /^https:\/\/catbox.moe\/c\/([\d\w-]+)\/?$/),
     ]
     static PROXY_REGEX = /^\/proxy\/api\/(\w+)\/chapter\/([\d\w-=]+)\/?/
     _name;

--- a/src/model/Proxy.js
+++ b/src/model/Proxy.js
@@ -9,7 +9,7 @@ export default class Proxy {
             return '/proxy/api/' + name + '/chapter/' + btoa(exec[0]) + '/';
         }),
         new Proxy('dynasty', 'Dynasty Scans', /^https:\/\/dynasty-scans.com\/chapters\/([\d\w_]+_ch[\d]+)$/),
-        new Proxy('catbox', 'Catbox', /^https:\/\/catbox.moe\/c\/([\d\w-]+)\/?$/),
+        new Proxy('catbox', 'Catbox', /^https:\/\/catbox.moe\/c\/(\w+)\/?$/),
     ]
     static PROXY_REGEX = /^\/proxy\/api\/(\w+)\/chapter\/([\d\w-=]+)\/?/
     _name;


### PR DESCRIPTION
Add the proxy for Catbox. Tested the regex, `/^https:\/\/catbox.moe\/c\/(\w+)\/?$/`, on RegExr with a few Catbox album links.